### PR TITLE
Add Travis CI build status badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: python
 python:
   - "2.7"
   - "3.4"
+
+script: py.test

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ Mendeley Python SDK
   :target: https://pypi.python.org/pypi/mendeley/
 .. image:: https://readthedocs.org/projects/mendeley-python/badge/?version=latest
   :target: https://readthedocs.org/projects/mendeley-python/?badge=latest
+.. image:: https://travis-ci.org/Mendeley/mendeley-python-sdk.svg?branch=master
+  :target: https://travis-ci.org/Mendeley/mendeley-python-sdk
 
 The Mendeley Python SDK provides access to the `Mendeley <http://www.mendeley.com>`_ API.  For more information on the
 API and its capabilities, see the `developer portal <http://dev.mendeley.com>`_.

--- a/test_config.yml.default
+++ b/test_config.yml.default
@@ -2,4 +2,4 @@ clientId: id
 clientSecret: secret
 redirectUri: https://example.com
 accessToken: token
-recordMode: none
+recordMode: all

--- a/test_config.yml.default
+++ b/test_config.yml.default
@@ -2,4 +2,4 @@ clientId: id
 clientSecret: secret
 redirectUri: https://example.com
 accessToken: token
-recordMode: all
+recordMode: none


### PR DESCRIPTION
Add Travis CI build status badge for master branch. No actual code changes. Travis has not been explicitly configured, so it is inferring build steps based on project structure - you may need to give it a helping hand if it doesn't quite figure out what you want.