### PR TITLE
Getting refresh_token from existing session in client credentials refresh

### DIFF
--- a/mendeley/auth.py
+++ b/mendeley/auth.py
@@ -107,4 +107,4 @@ class MendeleyAuthorizationCodeTokenRefresher():
         oauth = OAuth2Session(client=self.client, redirect_uri=self.redirect_uri, scope=['all'])
         oauth.compliance_hook['access_token_response'] = [handle_text_response]
 
-        session.token = oauth.refresh_token(self.token_url, auth=self.auth)
+        session.token = oauth.refresh_token(self.token_url, auth=self.auth, refresh_token=session.token.get('refresh_token', None))


### PR DESCRIPTION
Fixes #10

I had the same issue with refreshing tokens described in #10. The trouble is that the `Oauth2Session.refresh_token` function looks for a `refresh_token` key in the session's existing token (see [here](https://github.com/requests/requests-oauthlib/blob/master/requests_oauthlib/oauth2_session.py#L280)).