### PR TITLE
Add support for folders

### DIFF
--- a/mendeley/models/folders.py
+++ b/mendeley/models/folders.py
@@ -1,0 +1,103 @@
+import arrow
+import json
+from mendeley.response import SessionResponseObject, LazyResponseObject
+
+class Folder(SessionResponseObject):
+    """
+    A Mendeley folder.
+
+    .. attribute:: id
+    .. attribute:: name
+    .. attribute:: created
+    .. attribute:: modified
+    .. attribute:: parent_id
+    .. attribute:: group_id
+    """
+    content_type = 'application/vnd.mendeley-folder.1+json'
+
+    @property
+    def created(self):
+        """
+        an :class:`Arrow <arrow.arrow.Arrow>` object.
+        """
+        if 'created' in self.json:
+            return arrow.get(self.json['created'])
+        else:
+            return None
+
+    @property
+    def last_modified(self):
+        """
+        an :class:`Arrow <arrow.arrow.Arrow>` object.
+        """
+        if 'last_modified' in self.json:
+            return arrow.get(self.json['modified'])
+        elif 'created' in self.json:
+            return arrow.get(self.json['created'])
+        else:
+            return None
+
+    @property
+    def group(self):
+        """
+        a :class:`Group <mendeley.models.groups.Group>`.
+        """
+        if 'group_id' in self.json:
+            return self.session.groups.get_lazy(self.json['group_id'])
+        else:
+            return None
+
+    @property
+    def parent(self):
+        if 'parent_id' in self.json:
+            return self.session.folders.get_lazy(self.json['parent_id'])
+        else:
+            return None
+
+    @property
+    def documents(self):
+        """
+        a :class:`Documents <mendeley.resources.documents.Documents>` resource, from which
+        :class:`UserDocuments <mendeley.models.documents.UserDocument>` can be retrieved.
+        """
+        return self.session.folder_documents(folder_id=self.id, group_id=self.group_id)
+
+    @property
+    def files(self):
+        """
+        a :class:`Files <mendeley.resources.files.Files>` resource, from which
+        :class:`Files <mendeley.models.files.File>` can be retrieved.
+        """
+        return self.session.group_files(self.id)
+
+    def create(self, name):
+        """
+        Creates a new folder that is a subfolder of the current folder
+
+        :param name: name of the folder.
+        :return: a :class:`Folder <mendeley.models.folders.Folder>`.
+        """
+        return self.session.group_folders(self.group_id).create(name, parent_id=self.id)
+
+    def delete(self):
+        """
+        Permanently deletes this folder and any subfolders
+        """
+        self.session.delete('/folders/%s' % self.id)
+
+    def add_document(self, doc):
+
+        data = {'id':doc.id}
+        self.session.post('/folders/{}/documents'.format(self.id), data=json.dumps(data), headers={
+            'Accept': doc.content_type,
+            'Content-Type': doc.content_type
+        } )
+
+    def remove_document(self, doc):
+        self.session.delete('/folders/{}/documents/{}'.format(self.id, doc.id))
+
+    @classmethod
+    def fields(cls):
+        return ["id", "name", "created", "modified", "parent_id", "group_id"]
+
+

--- a/mendeley/models/groups.py
+++ b/mendeley/models/groups.py
@@ -56,6 +56,10 @@ class Group(SessionResponseObject):
         return self.session.group_members(self.id)
 
     @property
+    def folders(self):
+        return self.session.group_folders(self.id)
+
+    @property
     def documents(self):
         """
         a :class:`Documents <mendeley.resources.documents.Documents>` resource, from which

--- a/mendeley/resources/__init__.py
+++ b/mendeley/resources/__init__.py
@@ -5,3 +5,4 @@ from .files import Files
 from .groups import Groups, GroupMembers
 from .profiles import Profiles
 from .trash import Trash
+from .folders import Folders, FolderDocuments

--- a/mendeley/resources/folders.py
+++ b/mendeley/resources/folders.py
@@ -1,0 +1,99 @@
+import json
+from mendeley.models.folders import Folder
+
+from mendeley.resources.base import ListResource, GetByIdResource
+from mendeley.response import LazyResponseObject
+from mendeley.resources.base_documents import DocumentsBase
+from mendeley.models.documents import *
+
+class Folders(GetByIdResource, ListResource):
+    """
+    Top-level resource for accessing folders.
+    """
+    _url = '/folders'
+
+    def __init__(self, session, group_id=None):
+        self.session = session
+        self.group_id = group_id
+
+    def get(self, id):
+        """
+        Retrieves a folder by ID.
+
+        :param id: the ID of the folder to get.
+        :return: a :class:`Folder <mendeley.models.folders.Folder>`.
+        """
+        return super(Folders, self).get(id, group_id=self.group_id)
+
+    def list(self, page_size=None):
+        """
+        Retrieves folders that the logged-in user has, as a paginated collection.
+
+        :param page_size: the number of folders to return on each page.  Defaults to 20.
+        :return: a :class:`Page <mendeley.pagination.Page>` of :class:`Folders <mendeley.models.folders.Group>`.
+        """
+        return super(Folders, self).list(page_size, group_id=self.group_id)
+
+    def iter(self, page_size=None):
+        """
+        Retrieves folders that the logged-in user is a member of, as an iterator.
+
+        :param page_size: the number of folders to retrieve at a time.  Defaults to 20.
+        :return: an iterator of :class:`Folders <mendeley.models.folders.Group>`.
+        """
+        return super(Folders, self).iter(page_size, group_id=self.group_id)
+
+    def create(self, name, parent_id=None):
+        """
+        Creates a new folder
+
+        :param name: name of the folder.
+        :return: a :class:`Folder <mendeley.models.folders.Folder>`.
+        """
+        kwargs = {}
+        kwargs['name'] = name
+        kwargs['parent_id'] = parent_id
+        kwargs['group_id'] = self.group_id
+
+        content_type = Folder.content_type
+
+        rsp = self.session.post(self._url, data=json.dumps(kwargs), headers={
+            'Accept': content_type,
+            'Content-Type': content_type
+        })
+
+        return Folder(self.session, rsp.json())
+
+    @property
+    def _session(self):
+        return self.session
+
+    def _obj_type(self, **kwargs):
+        return Folder
+
+class FolderDocuments(DocumentsBase):
+    def __init__(self, session, folder_id, group_id):
+        super(FolderDocuments, self).__init__(session, group_id)
+        self.folder_id = folder_id
+
+    @staticmethod
+    def view_type(view):
+        return {
+            'all': UserAllDocument,
+            'bib': UserBibDocument,
+            'client': UserClientDocument,
+            'tags': UserTagsDocument,
+            'core': UserDocument,
+        }.get(view, UserDocument)
+
+    @property
+    def _url(self):
+        return '/folders/{}/documents'.format(self.folder_id)
+
+    def _obj_type(self, **kwargs):
+        class LazyDocument(object):
+            content_type = 'application/vnd.mendeley-document.1+json'#Folder.content_type #
+            def __call__(self2, session, rsp):
+                return LazyResponseObject(session, rsp['id'], super(FolderDocuments,self)._obj_type(**kwargs), lambda: session.group_documents(self.group_id).get(rsp['id'], kwargs['view']))
+        return LazyDocument()
+        

--- a/mendeley/session.py
+++ b/mendeley/session.py
@@ -61,6 +61,7 @@ class MendeleySession(OAuth2Session):
         self.groups = Groups(self)
         self.profiles = Profiles(self)
         self.trash = Trash(self, None)
+        self.folders = Folders(self)
 
     def group_members(self, group_id):
         return GroupMembers(self, group_id)
@@ -71,6 +72,9 @@ class MendeleySession(OAuth2Session):
     def group_trash(self, group_id):
         return Trash(self, group_id)
 
+    def group_folders(self, group_id):
+        return Folders(self, group_id)
+
     def group_files(self, group_id):
         return Files(self, group_id=group_id)
 
@@ -79,6 +83,9 @@ class MendeleySession(OAuth2Session):
 
     def catalog_files(self, catalog_id):
         return Files(self, catalog_id=catalog_id)
+
+    def folder_documents(self, folder_id, group_id):
+        return FolderDocuments(self, folder_id, group_id)
 
     def request(self, method, url, data=None, headers=None, **kwargs):
         full_url = urljoin(self.host, url)


### PR DESCRIPTION
Fixes #4 
folders exist as a property of the root Mendeley session and on any group object.

I haven't written any docs or tests yet (besides my own tests while developing), but would be happy to add some if interested in merging.

Example Usage:
```python
fold = mendeley_session.folders.list().items[0]
testfold = mendeley_session.folders.create('0000Test Folder0000') #creates a root folder
test_subfold = testfold.create('000Test Subfolder000') # creates a subfolder fo testfold
assert test_subfold.parent == testfold

doc = fold.documents.list(view='all')[0]
test_subfold.add_document(doc)
test_subfold.remove_document(doc)

print("Subfolder name: {}".format(test_subfold.name))
print("Parent folder name:{}".format(test_subfold.parent.name))
```